### PR TITLE
Upgrade to faraday 0.9.0 compatible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage
 ```ruby
 faraday = Faraday.new do |builder|
   builder.request :url_encoded
-  builder.use     :restrict_ip_addresses, deny_rfc6890: true,
+  builder.request :restrict_ip_addresses, deny_rfc6890: true,
                                           allow_localhost: true,
                                           deny: ['8.0.0.0/8',
                                                  '224.0.0.0/7'],

--- a/faraday-restrict-ip-addresses.gemspec
+++ b/faraday-restrict-ip-addresses.gemspec
@@ -1,7 +1,7 @@
-require_relative 'lib/faraday/restrict_ip_addresses'
+require_relative 'lib/faraday/restrict_ip_addresses/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.9']
+  spec.add_dependency 'faraday', '~>0.9.0'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ["Ben Lavender"]
   spec.description = %q{Restrict the IP addresses Faraday will connect to}

--- a/lib/faraday/restrict_ip_addresses.rb
+++ b/lib/faraday/restrict_ip_addresses.rb
@@ -1,10 +1,9 @@
-require 'faraday'
+require 'faraday/restrict_ip_addresses/version'
 require 'ipaddr'
 
 module Faraday
   class RestrictIPAddresses < Faraday::Middleware
     class AddressNotAllowed < Faraday::Error::ClientError ; end
-    VERSION = '0.0.3'
 
     RFC_1918_NETWORKS = %w(
       127.0.0.0/8
@@ -63,6 +62,5 @@ module Faraday
       Socket.gethostbyname(hostname).map { |a| IPAddr.new_ntoh(a) rescue nil }.compact
     end
   end
-
-  register_middleware restrict_ip_addresses: lambda { RestrictIPAddresses }
+  Request.register_middleware restrict_ip_addresses: lambda { RestrictIPAddresses }
 end

--- a/lib/faraday/restrict_ip_addresses/version.rb
+++ b/lib/faraday/restrict_ip_addresses/version.rb
@@ -1,0 +1,6 @@
+require 'faraday'
+module Faraday
+  class RestrictIPAddresses < Faraday::Middleware
+    VERSION = '0.1.0'
+  end
+end


### PR DESCRIPTION
This makes the middleware work with the newer versions of faraday.
