### PR TITLE
Normalize "rare" IP Address formats

### DIFF
--- a/lib/faraday/restrict_ip_addresses.rb
+++ b/lib/faraday/restrict_ip_addresses.rb
@@ -48,8 +48,6 @@ module Faraday
 
     def denied?(env)
       addresses(env[:url].host).any? { |a| denied_ip?(a) }
-    rescue SocketError
-      true
     end
 
     def denied_ip?(address)

--- a/lib/faraday/restrict_ip_addresses.rb
+++ b/lib/faraday/restrict_ip_addresses.rb
@@ -59,7 +59,7 @@ module Faraday
     end
 
     def addresses(hostname)
-      Socket.gethostbyname(hostname).map { |a| IPAddr.new_ntoh(a) rescue nil }.compact
+      Addrinfo.getaddrinfo(hostname, nil, :INET, :STREAM).map { |a| IPAddr.new(a.ip_address) }
     end
   end
   Request.register_middleware restrict_ip_addresses: lambda { RestrictIPAddresses }

--- a/lib/faraday/restrict_ip_addresses.rb
+++ b/lib/faraday/restrict_ip_addresses.rb
@@ -60,6 +60,9 @@ module Faraday
 
     def addresses(hostname)
       Addrinfo.getaddrinfo(hostname, nil, :INET, :STREAM).map { |a| IPAddr.new(a.ip_address) }
+    rescue SocketError => e
+      # In case of invalid hostname, return an empty list of addresses
+      []
     end
   end
   Request.register_middleware restrict_ip_addresses: lambda { RestrictIPAddresses }

--- a/lib/faraday/restrict_ip_addresses.rb
+++ b/lib/faraday/restrict_ip_addresses.rb
@@ -48,6 +48,8 @@ module Faraday
 
     def denied?(env)
       addresses(env[:url].host).any? { |a| denied_ip?(a) }
+    rescue SocketError
+      true
     end
 
     def denied_ip?(address)

--- a/spec/restrict_ip_addresses_spec.rb
+++ b/spec/restrict_ip_addresses_spec.rb
@@ -98,4 +98,13 @@ describe Faraday::RestrictIPAddresses do
       denied '0x7f.1'
       denied '0177.1'
     end
+
+    it "allows addresses for which DNS fails" do
+      middleware deny_rfc1918: true,
+                 deny: ['8.0.0.0/8'],
+                 allow: ['8.5.0.0/24', '192.168.14.0/24']
+      url = URI.parse("http://thisisanonexistinghostname.com")
+      Addrinfo.expects(:getaddrinfo).with(url.host, nil, :INET, :STREAM).raises(SocketError)
+      @rip.call(url: url)
+    end
 end

--- a/spec/restrict_ip_addresses_spec.rb
+++ b/spec/restrict_ip_addresses_spec.rb
@@ -8,14 +8,9 @@ describe Faraday::RestrictIPAddresses do
 
   def allowed(*addresses)
     url = URI.parse("http://test.com")
+    ips = addresses.map { |add| Addrinfo.tcp(add, nil) }
 
-    if addresses.include?('boom')
-      Addrinfo.expects(:getaddrinfo).with(url.host, nil, :INET, :STREAM).raises(SocketError)
-    else
-      ips = addresses.map { |add| Addrinfo.tcp(add, nil) }
-
-      Addrinfo.expects(:getaddrinfo).with(url.host, nil, :INET, :STREAM).returns(ips)
-    end
+    Addrinfo.expects(:getaddrinfo).with(url.host, nil, :INET, :STREAM).returns(ips)
 
     env = { url: url }
     @rip.call(env)
@@ -102,12 +97,5 @@ describe Faraday::RestrictIPAddresses do
       denied '127.0.0.1'
       denied '0x7f.1'
       denied '0177.1'
-    end
-
-    it "does not pass through failed lookups" do
-      middleware deny_rfc6890: true,
-                 allow_localhost: false
-
-      denied 'boom'
     end
 end


### PR DESCRIPTION
This pull request updates the address lookup logic to first normalize some of the more "rare" IP address formats like `http://0` as outlined in https://tools.ietf.org/html/rfc3986#page-45:

> These additional IP address formats are not allowed in the URI syntax
> due to differences between platform implementations.  However, they
> can become a security concern if an application attempts to filter
> access to resources based on the IP address in string literal format.
> If this filtering is performed, literals should be converted to
> numeric form and filtered based on the numeric value, and not on a
> prefix or suffix of the string form.

---

/cc @ptoomey3, @bhuga, @dbussink, & @mastahyeti for review