### PR TITLE
IPv6 support

### DIFF
--- a/lib/faraday/restrict_ip_addresses.rb
+++ b/lib/faraday/restrict_ip_addresses.rb
@@ -47,7 +47,7 @@ module Faraday
     end
 
     def denied?(env)
-      addresses(env[:url].host).any? { |a| denied_ip?(a) }
+      addresses(env[:url].hostname).any? { |a| denied_ip?(a) }
     end
 
     def denied_ip?(address)
@@ -59,7 +59,7 @@ module Faraday
     end
 
     def addresses(hostname)
-      Addrinfo.getaddrinfo(hostname, nil, :INET, :STREAM).map { |a| IPAddr.new(a.ip_address) }
+      Addrinfo.getaddrinfo(hostname, nil, :UNSPEC, :STREAM).map { |a| IPAddr.new(a.ip_address) }
     rescue SocketError => e
       # In case of invalid hostname, return an empty list of addresses
       []


### PR DESCRIPTION
This pull request modifies the "family" passed to `Addrinfo` to be "AF_UNSPEC", which, as per http://man7.org/linux/man-pages/man3/getaddrinfo.3.html outlines:

> The value AF_UNSPEC indicates that
> getaddrinfo() should return socket addresses for any
> address family (either IPv4 or IPv6, for example) that
> can be used with node and service.

So that we can support both IPv4 and IPv6 addresses.

Additionally, this commit modifies the way that the hostname is determined from the middleware. By using `URI::Generic.hostname` instead of `URI::Generic.host`, we can correctly determine the hostname of a URI formatted like `http://[::1]`.

---

/cc @ptoomey3, @dbussink, & @mastahyeti for review