### PR TITLE
Fix gem install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 PATH
   remote: .
   specs:
-    faraday-restrict-ip-addresses (0.0.2)
-      faraday (>= 0.8, < 0.9)
+    faraday-restrict-ip-addresses (0.1.2)
+      faraday (>= 0.9.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    faraday (0.8.9)
-      multipart-post (~> 1.2.0)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
     metaclass (0.0.2)
     method_source (0.8.2)
     mocha (1.0.0)
       metaclass (~> 0.0.1)
-    multipart-post (1.2.0)
+    multipart-post (2.0.0)
     pry (0.9.12.4)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -39,3 +39,6 @@ DEPENDENCIES
   mocha
   pry
   rspec
+
+BUNDLED WITH
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    faraday-restrict-ip-addresses (0.1.2)
+    faraday-restrict-ip-addresses (0.1.3)
       faraday (>= 0.9.0)
 
 GEM

--- a/faraday-restrict-ip-addresses.gemspec
+++ b/faraday-restrict-ip-addresses.gemspec
@@ -1,7 +1,7 @@
 require_relative 'lib/faraday/restrict_ip_addresses/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', '~>0.9.0'
+  spec.add_dependency 'faraday', '>= 0.9.0'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ["Ben Lavender"]
   spec.description = %q{Restrict the IP addresses Faraday will connect to}

--- a/lib/faraday/restrict_ip_addresses.rb
+++ b/lib/faraday/restrict_ip_addresses.rb
@@ -1,69 +1,74 @@
+require 'faraday'
 require 'faraday/restrict_ip_addresses/version'
 require 'ipaddr'
 
 module Faraday
-  class RestrictIPAddresses < Faraday::Middleware
+  module RestrictIPAddresses
     class AddressNotAllowed < Faraday::Error::ClientError ; end
 
-    RFC_1918_NETWORKS = %w(
-      127.0.0.0/8
-      10.0.0.0/8
-      172.16.0.0/12
-      192.168.0.0/16
-    ).map { |net| IPAddr.new(net) }
+    class Middleware < Faraday::Middleware
 
-    RFC_6890_NETWORKS = RFC_1918_NETWORKS + [
-      '0.0.0.0/8',         #  "This" Network [RFC1700, page 4]
-      '100.64.0.0/10',     #  Shared address space [6598, 6890]
-      #'128.0.0.0/16',      #  Reserved in 3330, not in 6890, has been assigned
-      '169.254.0.0/16',    #  Link Local [3927, 6890]
-      # '191.255.0.0/16'   #  Reserved in 3330, not in 6890, has been assigned
-      '192.0.0.0/24',      #  Reserved but subject to allocation [6890]
-      '192.0.0.0/29',      #  DS-Lite                        [6333, 6890]. Redundant with above, included for completeness.
-      '192.0.2.0/24',      #  Documentation                  [5737, 6890]
-      '192.88.99.0/24',    #  6to4 Relay Anycast             [3068, 6890]
-      '198.18.0.0/15',     #  Network Interconnect Device Benchmark Testing [2544, 6890]
-      '198.51.100.0/24',   #  Documentation                  [5737, 6890]
-      '203.0.113.0/24',    #  Documentation                  [5737, 6890]
-      '224.0.0.0/4',       #  Multicast                      [11112]
-      '240.0.0.0/4',       #  Reserved for Future Use        [6890]
-      '255.255.255.255/32' #  Reserved for Future Use        [6890]
-    ].map { |net| IPAddr.new(net) }
+      RFC_1918_NETWORKS = %w(
+        127.0.0.0/8
+        10.0.0.0/8
+        172.16.0.0/12
+        192.168.0.0/16
+      ).map { |net| IPAddr.new(net) }
 
-    def initialize(app, options = {})
-      super(app)
-      @denied_networks   = (options[:deny] || []).map  { |n| IPAddr.new(n) }
-      @allowed_networks  = (options[:allow] || []).map { |n| IPAddr.new(n) }
+      RFC_6890_NETWORKS = RFC_1918_NETWORKS + [
+        '0.0.0.0/8',         #  "This" Network [RFC1700, page 4]
+        '100.64.0.0/10',     #  Shared address space [6598, 6890]
+        #'128.0.0.0/16',      #  Reserved in 3330, not in 6890, has been assigned
+        '169.254.0.0/16',    #  Link Local [3927, 6890]
+        # '191.255.0.0/16'   #  Reserved in 3330, not in 6890, has been assigned
+        '192.0.0.0/24',      #  Reserved but subject to allocation [6890]
+        '192.0.0.0/29',      #  DS-Lite                        [6333, 6890]. Redundant with above, included for completeness.
+        '192.0.2.0/24',      #  Documentation                  [5737, 6890]
+        '192.88.99.0/24',    #  6to4 Relay Anycast             [3068, 6890]
+        '198.18.0.0/15',     #  Network Interconnect Device Benchmark Testing [2544, 6890]
+        '198.51.100.0/24',   #  Documentation                  [5737, 6890]
+        '203.0.113.0/24',    #  Documentation                  [5737, 6890]
+        '224.0.0.0/4',       #  Multicast                      [11112]
+        '240.0.0.0/4',       #  Reserved for Future Use        [6890]
+        '255.255.255.255/32' #  Reserved for Future Use        [6890]
+      ].map { |net| IPAddr.new(net) }
 
-      @denied_networks += RFC_1918_NETWORKS if options[:deny_rfc1918]
-      @denied_networks += RFC_6890_NETWORKS if options[:deny_rfc6890]
-      @denied_networks.uniq!
-      @allowed_networks += [IPAddr.new('127.0.0.1')] if options[:allow_localhost]
+      def initialize(app, options = {})
+        super(app)
+        @denied_networks   = (options[:deny] || []).map  { |n| IPAddr.new(n) }
+        @allowed_networks  = (options[:allow] || []).map { |n| IPAddr.new(n) }
+
+        @denied_networks += RFC_1918_NETWORKS if options[:deny_rfc1918]
+        @denied_networks += RFC_6890_NETWORKS if options[:deny_rfc6890]
+        @denied_networks.uniq!
+        @allowed_networks += [IPAddr.new('127.0.0.1')] if options[:allow_localhost]
+      end
+
+      def call(env)
+        raise AddressNotAllowed.new "Address not allowed for #{env[:url]}" if denied?(env)
+        @app.call(env)
+      end
+
+      def denied?(env)
+        addresses(env[:url].hostname).any? { |a| denied_ip?(a) }
+      end
+
+      def denied_ip?(address)
+        @denied_networks.any? { |net| net.include?(address) and !allowed_ip?(address) }
+      end
+
+      def allowed_ip?(address)
+        @allowed_networks.any? { |net| net.include? address }
+      end
+
+      def addresses(hostname)
+        Addrinfo.getaddrinfo(hostname, nil, :UNSPEC, :STREAM).map { |a| IPAddr.new(a.ip_address) }
+      rescue SocketError => e
+        # In case of invalid hostname, return an empty list of addresses
+        []
+      end
     end
 
-    def call(env)
-      raise AddressNotAllowed.new "Address not allowed for #{env[:url]}" if denied?(env)
-      @app.call(env)
-    end
-
-    def denied?(env)
-      addresses(env[:url].hostname).any? { |a| denied_ip?(a) }
-    end
-
-    def denied_ip?(address)
-      @denied_networks.any? { |net| net.include?(address) and !allowed_ip?(address) }
-    end
-
-    def allowed_ip?(address)
-      @allowed_networks.any? { |net| net.include? address }
-    end
-
-    def addresses(hostname)
-      Addrinfo.getaddrinfo(hostname, nil, :UNSPEC, :STREAM).map { |a| IPAddr.new(a.ip_address) }
-    rescue SocketError => e
-      # In case of invalid hostname, return an empty list of addresses
-      []
-    end
+    Request.register_middleware restrict_ip_addresses: lambda { Faraday::RestrictIPAddresses::Middleware }
   end
-  Request.register_middleware restrict_ip_addresses: lambda { RestrictIPAddresses }
 end

--- a/lib/faraday/restrict_ip_addresses/version.rb
+++ b/lib/faraday/restrict_ip_addresses/version.rb
@@ -1,6 +1,5 @@
-require 'faraday'
 module Faraday
-  class RestrictIPAddresses < Faraday::Middleware
+  module RestrictIPAddresses
     VERSION = '0.1.3'
   end
 end

--- a/lib/faraday/restrict_ip_addresses/version.rb
+++ b/lib/faraday/restrict_ip_addresses/version.rb
@@ -1,6 +1,6 @@
 require 'faraday'
 module Faraday
   class RestrictIPAddresses < Faraday::Middleware
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/spec/restrict_ip_addresses_spec.rb
+++ b/spec/restrict_ip_addresses_spec.rb
@@ -1,7 +1,7 @@
 require 'faraday/restrict_ip_addresses'
 require 'spec_helper'
 
-describe Faraday::RestrictIPAddresses do
+describe Faraday::RestrictIPAddresses::Middleware do
   def middleware(opts = {})
     @rip = described_class.new(lambda{|env| env}, opts)
   end


### PR DESCRIPTION
This patch includes changes from https://github.com/bhuga/faraday-restrict-ip-addresses/pull/7 PR that needs to be merged first.

Gem install depends on the `faraday` gem being installed before running `bundle install` which is not ideal. The reason for that is because the gemspec needs `Faraday::RestrictIPAddresses::VERSION` const and then the version file loads `faraday` that it doesn't have to with a proper namespace setup.

In order to fix this, I've changed `Faraday::RestrictIPAddresses` to be module nesting the `Middleware` class that is auto-registered and I've kept `Faraday::RestrictIPAddresses::AddressNotAllowed` error class at the same level because it's exposed publicly to keep things backward-compatible.

@bhuga Thoughts?